### PR TITLE
Look for higher-level zones

### DIFF
--- a/certbot_dns_he/dns_he.py
+++ b/certbot_dns_he/dns_he.py
@@ -60,7 +60,7 @@ class Authenticator(dns_common.DNSAuthenticator):
 
         # Fetch all domains and find the target by name
         all_domains = self.dns_api.get_domains()
-        target_domain = next((x for x in all_domains if x.name.lower() == domain.lower()), None)
+        target_domain = next((x for x in all_domains if domain.lower().endswith(x.name.lower())), None)
 
         if not target_domain:
             raise errors.PluginError('Unable to find domain: {0}'.format(domain))
@@ -89,7 +89,7 @@ class Authenticator(dns_common.DNSAuthenticator):
 
         # Fetch all domains and find the target by name
         all_domains = self.dns_api.get_domains()
-        target_domain = next((x for x in all_domains if x.name.lower() == domain.lower()), None)
+        target_domain = next((x for x in all_domains if domain.lower().endswith(x.name.lower())), None)
 
         if not target_domain:
             raise errors.PluginError('Unable to find domain: {0}'.format(domain))


### PR DESCRIPTION
When trying to verify a domain such as "apples.foo.bar", it is totally fine to have a zone such as "foo.bar" which you can add the "apples" TXT record to.  This changes out the strict equality check of existing zones for an "ends with" check.